### PR TITLE
Generate guid for shapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ version = "0.1.0"
 dependencies = [
  "eyre",
  "math",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/app/src/components/canvas.rs
+++ b/app/src/components/canvas.rs
@@ -5,7 +5,7 @@ use gloo::{
 use web_sys::{console, wasm_bindgen::JsCast};
 use yew::prelude::*;
 
-use editor::Tool;
+use editor::{GuidGenerator, Tool};
 use math::CanvasPoint;
 
 use crate::{
@@ -14,6 +14,8 @@ use crate::{
     use_shapes::{ShapeCatalogAction, ShapeCatalogState},
     CameraState, CameraStateAction,
 };
+
+pub static GUID_GENERATOR: GuidGenerator = GuidGenerator::new();
 
 #[function_component]
 pub fn Canvas() -> Html {

--- a/app/src/components/mod.rs
+++ b/app/src/components/mod.rs
@@ -1,4 +1,4 @@
-pub use canvas::Canvas;
+pub use canvas::*;
 pub use inner_canvas::InnerCanvas;
 pub use toolbar::Toolbar;
 

--- a/app/src/use_pointer.rs
+++ b/app/src/use_pointer.rs
@@ -1,3 +1,4 @@
+use crate::components::GUID_GENERATOR;
 use crate::use_shapes::{ShapeCatalogAction, ShapeCatalogState};
 use crate::{CameraState, CameraStateAction};
 use editor::{get_box, Tool};
@@ -12,7 +13,7 @@ pub fn use_pointer_down_callback(
     temp_canvas_position: UseStateHandle<CanvasPoint>,
     global_pointer_down: UseStateHandle<bool>,
     shape_catalog: UseReducerHandle<ShapeCatalogState>,
-    active_shape: UseStateHandle<Option<usize>>,
+    active_shape: UseStateHandle<Option<u32>>,
     selection_box: UseStateHandle<Option<(CanvasPoint, CanvasPoint)>>,
 ) -> Callback<PointerEvent> {
     let shape_catalog = shape_catalog.clone();
@@ -31,7 +32,7 @@ pub fn use_pointer_down_callback(
                 Tool::Hand => temp_canvas_position.set((*camera).canvas_position()),
                 Tool::Rect => {
                     shape_catalog.dispatch(ShapeCatalogAction::UnselectAll);
-                    let next_id = (*shape_catalog).next_id();
+                    let next_id = GUID_GENERATOR.next_guid();
                     shape_catalog.dispatch(ShapeCatalogAction::UpsertShape {
                         id: next_id,
                         position: pointer_position,
@@ -66,7 +67,7 @@ pub fn use_pointer_move_callback(
     temp_canvas_position: CanvasPoint,
     camera: UseReducerHandle<CameraState>,
     shape_catalog: UseReducerHandle<ShapeCatalogState>,
-    active_shape: UseStateHandle<Option<usize>>,
+    active_shape: UseStateHandle<Option<u32>>,
     client_position: UseStateHandle<Option<(i32, i32)>>,
     selection_box: UseStateHandle<Option<(CanvasPoint, CanvasPoint)>>,
 ) -> Callback<PointerEvent> {
@@ -144,7 +145,7 @@ pub fn use_pointer_up_callback(
     temp_canvas_position: UseStateHandle<CanvasPoint>,
     global_pointer_down: UseStateHandle<bool>,
     shape_catalog: UseReducerHandle<ShapeCatalogState>,
-    active_shape: UseStateHandle<Option<usize>>,
+    active_shape: UseStateHandle<Option<u32>>,
     selection_box: UseStateHandle<Option<(CanvasPoint, CanvasPoint)>>,
 ) -> Callback<PointerEvent> {
     Callback::from({

--- a/app/src/use_shapes.rs
+++ b/app/src/use_shapes.rs
@@ -8,7 +8,7 @@ use crate::CameraState;
 
 pub enum ShapeCatalogAction {
     UpsertShape {
-        id: usize,
+        id: u32,
         position: CanvasPoint,
         width_height: CanvasPoint,
         selected: bool,
@@ -29,7 +29,7 @@ pub enum ShapeCatalogAction {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ShapeCatalogState {
-    shapes: BTreeMap<usize, Shape>,
+    shapes: BTreeMap<u32, Shape>,
 }
 
 impl ShapeCatalogState {
@@ -37,7 +37,7 @@ impl ShapeCatalogState {
         self.shapes.len()
     }
 
-    pub fn selected(&self) -> Vec<usize> {
+    pub fn selected(&self) -> Vec<u32> {
         self.shapes
             .iter()
             .filter(|(_, s)| match s {

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2021"
 
 [dependencies]
 eyre.workspace = true
-
 math = { path = "../math" }
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }

--- a/editor/src/guid.rs
+++ b/editor/src/guid.rs
@@ -1,0 +1,31 @@
+use std::sync::atomic::{self, AtomicU32};
+
+#[derive(Debug)]
+pub struct GuidGenerator(AtomicU32);
+
+pub type Guid = u32;
+
+impl GuidGenerator {
+    pub const fn new() -> Self {
+        Self(AtomicU32::new(0))
+    }
+
+    pub fn next_guid(&self) -> Guid {
+        self.0.fetch_add(1, atomic::Ordering::Relaxed) as Guid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn test_guid_gen() {
+        let gen = GuidGenerator::new();
+
+        for i in 0..100 {
+            assert_eq!(i, gen.next_guid())
+        }
+    }
+}

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1,6 +1,8 @@
+mod guid;
 mod shape;
 mod tool;
 
+pub use guid::GuidGenerator;
 use math::CanvasPoint;
 pub use shape::{Rectangle, Shape};
 pub use tool::Tool;


### PR DESCRIPTION
Currently we rely on the `BTreeMap`'s dynamic size as the next id. This commit uses a guid generator to generate shape ids. It uses `Atomic<u32>` underneath the hood.