### PR TITLE
perf: Remove `classes!()`

### DIFF
--- a/app/src/use_shapes.rs
+++ b/app/src/use_shapes.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use editor::{Rectangle, Shape};
 use math::CanvasPoint;
-use yew::{classes, html, virtual_dom::VNode, Html, Reducible};
+use yew::{classes, html, virtual_dom::VNode, Classes, Html, Reducible};
 
 use crate::CameraState;
 
@@ -48,6 +48,11 @@ impl ShapeCatalogState {
     }
 
     pub fn html(&self, camera: &CameraState) -> VNode {
+        let z = camera.zoom();
+
+        let selected: Classes = format!("stroke-blue-800 stroke-w-[{z}px] fill-green-300").into();
+        let unselected: Classes = "stroke-black stroke-w-1 fill-orange-300".into();
+
         self.shapes
             .iter()
             .map(|(k, s)| {
@@ -57,26 +62,11 @@ impl ShapeCatalogState {
                     Shape::Rectangle(r) => {
                         let path = r.path();
 
-                        let stroke = if r.selected {
-                            "stroke-blue-800"
+                        let class = if r.selected {
+                            selected.clone()
                         } else {
-                            "stroke-black"
+                            unselected.clone()
                         };
-
-                        let z = camera.zoom();
-
-                        let stroke_w = if r.selected {
-                            format!("stroke-width-[{}px]", 2 as f32 / z)
-                        } else {
-                            format!("stroke-width-1")
-                        };
-
-                        let fill = if r.selected {
-                            "fill-green-300"
-                        } else {
-                            "fill-orange-300"
-                        };
-                        let class = classes!(stroke, stroke_w, fill);
 
                         html! {
                             <path key={k} d={path} class={class}/>


### PR DESCRIPTION
We currently spend 23% in this profile converting `&String` into `yew::Classes`. 

![Screenshot 2024-09-20 at 6 59 38 PM](https://github.com/user-attachments/assets/91a7646f-97f0-45f8-b547-c9ff304a723d)


This commit is 6x faster for small scenes and 2-4x faster for large scenes.

![Screenshot 2024-09-20 at 7 02 23 PM](https://github.com/user-attachments/assets/158137f8-edfd-4ce1-a49e-81ad3b50e914)


Another thing to note is the use of `Classes`.clone() is permissible since `Classes` is an `Rc` [source](https://docs.rs/yew/latest/src/yew/html/classes.rs.html#15)
